### PR TITLE
CSV and pardot

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -641,7 +641,7 @@ class Extension extends \Bolt\BaseExtension
                 //execute post
                 $result = curl_exec($ch);
                 if ($result == FALSE){ // Oops something went wrong. Probably improper FormHandler URL or Pardot config.
-                    \Dumper::dump("Couldn't send data over cURL to Pardot. Make sure you are using the correct FormHandler URL and the Pardot FormHandler is properly configured.");
+                    echo "Couldn't send data over cURL to Pardot. Make sure you are using the correct FormHandler URL and the Pardot FormHandler is properly configured.";
                     $this->app['log']->add("Couldn't send data over cURL to Pardot. Make sure you are using the correct FormHandler URL and the Pardot FormHandler is properly configured.", 3);
                 }
             } catch (\Doctrine\DBAL\DBALException $e) {

--- a/Extension.php
+++ b/Extension.php
@@ -619,8 +619,8 @@ class Extension extends \Bolt\BaseExtension
         // set the default recipient for this form
         if (!empty($formconfig['recipient_email'])) {
             $sendToEmailsArray = explode(',', $formconfig['recipient_email']);
-            foreach ($sendToEmailsArray as $k => &$v){
-                $v = trim($v);
+            foreach ($sendToEmailsArray as &$emailAddress){
+                $emailAddress = trim($emailAddress);
             }
             $message->setTo(array_fill_keys($sendToEmailsArray, $formconfig['recipient_name']));
             $this->app['log']->add('Set Recipient for '. $formname . ' to '. $formconfig['recipient_email'], 3);
@@ -656,16 +656,16 @@ class Extension extends \Bolt\BaseExtension
             // only add other recipients when not in testmode
             if(!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
                 $sendToEmailsArray = explode(',', $formconfig['recipient_cc_email']);
-                foreach ($sendToEmailsArray as $k => &$v){
-                    $v = trim($v);
+                foreach ($sendToEmailsArray as &$emailAddress){
+                    $emailAddress = trim($emailAddress);
                 }
                 $message->setCc(array_fill_keys($sendToEmailsArray, $formconfig['recipient_cc_email']));
                 $this->app['log']->add('Added Cc for '. $formname . ' to '. $formconfig['recipient_cc_email'], 3);
             }
             if(!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
                 $sendToEmailsArray = explode(',', $formconfig['recipient_bcc_email']);
-                foreach ($sendToEmailsArray as $k => &$v){
-                    $v = trim($v);
+                foreach ($sendToEmailsArray as &$emailAddress){
+                    $emailAddress = trim($emailAddress);
                 }
                 $message->setCc(array_fill_keys($sendToEmailsArray, $formconfig['recipient_bcc_email']));
                 $this->app['log']->add('Added Bcc for '. $formname . ' to '. $formconfig['recipient_bcc_email'], 3);

--- a/Extension.php
+++ b/Extension.php
@@ -25,7 +25,7 @@ class Extension extends \Bolt\BaseExtension
     {
         return Extension::NAME;
     }
-    
+
     /**
      * Allow users to place {{ simpleforms() }} tags into content, if
      * `allowtwig: true` is set in the contenttype.
@@ -584,7 +584,6 @@ class Extension extends \Bolt\BaseExtension
             \Dumper::dump('Prepared files for '.$formname);
             \Dumper::dump($data);
         }
-        
 
         // Attempt to insert the data into a table, if specified..
         if (!empty($formconfig['insert_into_table'])) {

--- a/Extension.php
+++ b/Extension.php
@@ -37,7 +37,6 @@ class Extension extends \Bolt\BaseExtension
         return true;
     }
 
-
     public function initialize()
     {
         if ($this->app['config']->getWhichEnd() == 'frontend') {

--- a/Extension.php
+++ b/Extension.php
@@ -26,17 +26,6 @@ class Extension extends \Bolt\BaseExtension
         return Extension::NAME;
     }
 
-    /**
-     * Allow users to place {{ simpleforms() }} tags into content, if
-     * `allowtwig: true` is set in the contenttype.
-     *
-     * @return boolean
-     */
-    public function isSafe()
-    {
-        return true;
-    }
-
     public function initialize()
     {
         if ($this->app['config']->getWhichEnd() == 'frontend') {
@@ -396,6 +385,14 @@ class Extension extends \Bolt\BaseExtension
             \Dumper::dump($data);
             \Dumper::dump($this->app['request']->files);
         }
+        
+        // Check recipients arrays & push/convert single recipients to front of it.
+        if (empty($formconfig['recipients']))       $formconfig['recipients'] = array();
+        if (empty($formconfig['recipients_cc']))    $formconfig['recipients_cc'] = array();
+        if (empty($formconfig['recipients_bcc']))   $formconfig['recipients_bcc'] = array();
+        if (!empty($formconfig['recipient_email'])) array_unshift($formconfig['recipients'], array('email' => $formconfig['recipient_email'], 'name' => $formconfig['recipient_name']));
+        if (!empty($formconfig['recipient_cc_email'])) array_unshift($formconfig['recipients_cc'], array('email' => $formconfig['recipient_cc_email'], 'name' => $formconfig['recipient_cc_name']));
+        if (!empty($formconfig['recipient_bcc_email'])) array_unshift($formconfig['recipients_bcc'], array('email' => $formconfig['recipient_bcc_email'], 'name' => $formconfig['recipient_bcc_name']));
 
         // $data contains the posted data. For legibility, change boolean fields to "yes" or "no".
         foreach($data as $key => $value) {
@@ -440,38 +437,23 @@ class Extension extends \Bolt\BaseExtension
                         case 'to_email':
                             // add another recipient
                             // add the values to the formconfig in case we want to see this later
-                            if (!empty($formconfig['recipients'])) { 
-                                $formconfig['recipients'][] = array('name' => $tmp_name, 'email' => $tmp_email);
-                            } else {
-                                $formconfig['recipient_email'] = $tmp_email;
-                                $formconfig['recipient_name'] = $tmp_name;
-                            }
+                            $formconfig['recipients'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                             if($formconfig['debugmode']==true) {
-                                \Dumper::dump('Overriding recipient_email for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
+                                \Dumper::dump('Adding to recipients for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
                             }
                             break;
                         case 'cc_email':
                             // add another carbon copy recipient
-                            if (!empty($formconfig['recipients_cc'])) { 
-                                $formconfig['recipients_cc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
-                            } else {
-                                $formconfig['recipient_cc_email'] = $tmp_email;
-                                $formconfig['recipient_cc_name'] = $tmp_name;
-                            }
+                            $formconfig['recipients_cc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                             if($formconfig['debugmode']==true) {
-                                \Dumper::dump('Overriding recipient_cc_email for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
+                                \Dumper::dump('Adding to recipients_cc for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
                             }
                             break;
                         case 'bcc_email':
                             // add another blind carbon copy recipient
-                            if (!empty($formconfig['recipients_bcc'])) { 
-                                $formconfig['recipients_bcc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
-                            } else {
-                                $formconfig['recipient_bcc_email'] = $tmp_email;
-                                $formconfig['recipient_bcc_name'] = $tmp_name;
-                            }
+                            $formconfig['recipients_bcc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                             if($formconfig['debugmode']==true) {
-                                \Dumper::dump('Overriding recipient_bcc_email for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
+                                \Dumper::dump('Adding to recipients_bcc for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
                             }
                             break;
                     }
@@ -621,24 +603,19 @@ class Extension extends \Bolt\BaseExtension
 
         if (!empty($formconfig['mail_subject'])) {
             $subject = $formconfig['mail_subject'];
-        }
-        else {
+        } else {
             $subject = '[SimpleForms] ' . $formname;
         }
 
         if (empty($formconfig['from_email'])) {
             if (!empty($formconfig['recipients'][0]['name'])) {
                 $formconfig['from_email'] = $formconfig['recipients'][0]['email'];
-            } else {
-                $formconfig['from_email'] = $formconfig['recipient_email'];
             }
         }
 
         if (empty($formconfig['from_name'])) {
             if (!empty($formconfig['recipients'][0]['name'])) {
                 $formconfig['from_name'] = $formconfig['recipients'][0]['name'];
-            } else {
-                $formconfig['from_name'] = $formconfig['recipient_name'];
             }
         }
 
@@ -656,9 +633,6 @@ class Extension extends \Bolt\BaseExtension
             }
             $message->setTo($sendToEmailsArray);
             $this->app['log']->add('Set Recipients for '. $formname . ' to '. implode(', ', array_keys($sendToEmailsArray)), 3);
-        } else if (!empty($formconfig['recipient_email'])) { // Fallback/Depr.
-            $message->setTo(array($formconfig['recipient_email'] => $formconfig['recipient_name']));
-            $this->app['log']->add('Set Recipient for '. $formname . ' to '. $formconfig['recipient_email'], 3);
         }
 
         // set the default sender for this form
@@ -673,18 +647,23 @@ class Extension extends \Bolt\BaseExtension
                 $message->attach($attachment);
             }
         }
+        
+        // utility lambda to grab email from set (array) of name & email
+        $getFromEmailSet = function($arrayOfEmailName, $property = 'email'){
+            return $arrayOfEmailName[$property];
+        };
 
         // check for testmode
         if($formconfig['testmode']==true) {
             // override recipient with debug recipient
-            $message->setTo(array($formconfig['testmode_recipient'] => $formconfig['recipient_name']));
+            $message->setTo(array($formconfig['testmode_recipient'] => $formconfig['recipients'][0]['name']));
 
             // do not add other cc and bcc addresses in testmode
-            if(!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
-                $this->app['log']->add('Did not set Cc for '. $formname . ' to '. $formconfig['recipient_cc_email'] . ' (in testmode)', 3);
+            if(!empty($formconfig['recipients_cc']) && $formconfig['recipients']!=$formconfig['recipients_cc']) {
+                $this->app['log']->add('Did not set Cc for '. $formname . ' (in testmode)', 3);
             }
-            if(!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
-                $this->app['log']->add('Did not set Bcc for '. $formname . ' to '. $formconfig['recipient_bcc_email'] . ' (in testmode)', 3);
+            if(!empty($formconfig['recipients_bcc']) && $formconfig['recipients']!=$formconfig['recipients_bcc']) {
+                $this->app['log']->add('Did not set Bcc for '. $formname . ' (in testmode)', 3);
             }
         }
         else {
@@ -692,28 +671,22 @@ class Extension extends \Bolt\BaseExtension
             if(!empty($formconfig['recipients_cc'])) {
                 $sendToEmailsArray = array();
                 foreach ($formconfig['recipients_cc'] as $emailEntry){
-                    if (!in_array($emailEntry, $formconfig['recipients'])){
+                    if (!in_array($emailEntry['email'], array_map($getFromEmailSet, $formconfig['recipients']))){
                         $sendToEmailsArray[$emailEntry['email']] = $emailEntry['name'];
                     }
                 }
                 $message->setCc($sendToEmailsArray);
                 $this->app['log']->add('Set CC for '. $formname . ' to '. implode(', ', array_keys($sendToEmailsArray)), 3);
-            } else if (!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
-                $message->setCc(array($formconfig['recipient_cc_email'] => $formconfig['recipient_cc_name']));
-                $this->app['log']->add('Set CC for '. $formname . ' to '. $formconfig['recipient_cc_email'], 3);
             }
             if(!empty($formconfig['recipients_bcc'])) {
                 $sendToEmailsArray = array();
                 foreach ($formconfig['recipients_bcc'] as $emailEntry){
-                    if (!in_array($emailEntry, $formconfig['recipients'])){
+                    if (!in_array($emailEntry['email'], array_map($getFromEmailSet, $formconfig['recipients']))){
                         $sendToEmailsArray[$emailEntry['email']] = $emailEntry['name'];
                     }
                 }
                 $message->setBcc($sendToEmailsArray);
                 $this->app['log']->add('Added Bcc for '. $formname . ' to '. implode(', ', array_keys($sendToEmailsArray)), 3);
-            } else if (!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
-                $message->setBcc(array($formconfig['recipient_bcc_email'] => $formconfig['recipient_bcc_name']));
-                $this->app['log']->add('Set BCC for '. $formname . ' to '. $formconfig['recipient_bcc_email'], 3);
             }
 
             // check for other email addresses to be added
@@ -728,11 +701,8 @@ class Extension extends \Bolt\BaseExtension
                             $tmp_name = $data[$values['use_with']];
                             if(!$tmp_name) {
                                 $tmp_name = $tmp_email;
-                            } else {
-                                $formconfig['recipient_name'] = $tmp_name;
-                            }
-                        }
-                        else {
+                            } 
+                        } else {
                             $tmp_name = $tmp_email;
                         }
                     }
@@ -762,26 +732,26 @@ class Extension extends \Bolt\BaseExtension
                             case 'to_email':
                                 // check if recipient name is something useful
                                 // if it is already set somewhere use that
-                                if(!isset($formconfig['recipient_name'])) {
-                                    $formconfig['recipient_name'] = $tmp_name;
+                                if(!isset($formconfig['recipients'][0]['name']) || empty($formconfig['recipients'][0]['name'])) {
+                                    $formconfig['recipients'][0]['name'] = $tmp_name;
                                 } else {
-                                    $tmp_name = $formconfig['recipient_name'];
+                                    $tmp_name = $formconfig['recipients'][0]['name'];
                                 }
+                                
                                 // add another recipient
-
                                 $message->addTo($tmp_email, $tmp_name);
                                 // add the values to the formconfig in case we want to see this later
-                                if (empty($formconfig['recipient_email'])) {
-                                    $formconfig['recipient_email'] = $tmp_email;
-                                }
+                                $formconfig['recipients'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                                 break;
                             case 'cc_email':
                                 // add another carbon copy recipient
                                 $message->addCc($tmp_email, $tmp_name);
+                                $formconfig['recipients_cc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                                 break;
                             case 'bcc_email':
                                 // add another blind carbon copy recipient
                                 $message->addBcc($tmp_email, $tmp_name);
+                                $formconfig['recipients_bcc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                                 break;
                         }
                     }
@@ -792,17 +762,22 @@ class Extension extends \Bolt\BaseExtension
         // log the attempt
         $this->app['log']->add('Sending message '. $formname
                                . ' from '. $formconfig['from_email']
-                               . ' to '. $formconfig['recipient_email'], 3);
+                               . ' to '. implode(', ', array_map($getFromEmailSet, $formconfig['recipients'])), 3);
 
         $res = $this->app['mailer']->send($message);
 
         // log the result of the attempt
         if ($res) {
             if($formconfig['testmode']) {
-                $this->app['log']->add('Sent email from ' . $formname . ' to '. $formconfig['testmode_recipient'] . ' (in testmode) - ' . $formconfig['recipient_name'], 3);
+                $this->app['log']->add('Sent email from ' . $formname . ' to '. $formconfig['testmode_recipient'] . ' (in testmode)', 3);
             }
             else {
-                $this->app['log']->add('Sent email from ' . $formname . ' to '. $formconfig['recipient_email'] . ' - ' . $formconfig['recipient_name'], 3);
+                $this->app['log']->add('Sent email from ' . $formname . ' to '. implode(', ', array_map($getFromEmailSet, $formconfig['recipients'])) . ' - ' . implode(', ', array_map($getFromEmailSet, $formconfig['recipients'], array_fill(0, count($formconfig['recipients']), 'name'))), 3);
+            }
+            if($formconfig['debugmode']==true) {
+                \Dumper::dump('Recipients Below');
+                \Dumper::dump($formconfig['recipients']);
+                \Dumper::dump(array_map($getFromEmailSet, $formconfig['recipients']));
             }
         }
 

--- a/Extension.php
+++ b/Extension.php
@@ -619,8 +619,8 @@ class Extension extends \Bolt\BaseExtension
         // set the default recipient for this form
         if (!empty($formconfig['recipient_email'])) {
             $sendToEmailsArray = explode(',', $formconfig['recipient_email']);
-            foreach ($sendToEmailsArray as $k => $v){
-              $v = trim($v);
+            foreach ($sendToEmailsArray as $k => &$v){
+                $v = trim($v);
             }
             $message->setTo(array_fill_keys($sendToEmailsArray, $formconfig['recipient_name']));
             $this->app['log']->add('Set Recipient for '. $formname . ' to '. $formconfig['recipient_email'], 3);
@@ -656,16 +656,16 @@ class Extension extends \Bolt\BaseExtension
             // only add other recipients when not in testmode
             if(!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
                 $sendToEmailsArray = explode(',', $formconfig['recipient_cc_email']);
-                foreach ($sendToEmailsArray as $k => $v){
-                  $v = trim($v);
+                foreach ($sendToEmailsArray as $k => &$v){
+                    $v = trim($v);
                 }
                 $message->setCc(array_fill_keys($sendToEmailsArray, $formconfig['recipient_cc_email']));
                 $this->app['log']->add('Added Cc for '. $formname . ' to '. $formconfig['recipient_cc_email'], 3);
             }
             if(!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
                 $sendToEmailsArray = explode(',', $formconfig['recipient_bcc_email']);
-                foreach ($sendToEmailsArray as $k => $v){
-                  $v = trim($v);
+                foreach ($sendToEmailsArray as $k => &$v){
+                    $v = trim($v);
                 }
                 $message->setCc(array_fill_keys($sendToEmailsArray, $formconfig['recipient_bcc_email']));
                 $this->app['log']->add('Added Bcc for '. $formname . ' to '. $formconfig['recipient_bcc_email'], 3);

--- a/Extension.php
+++ b/Extension.php
@@ -618,7 +618,11 @@ class Extension extends \Bolt\BaseExtension
 
         // set the default recipient for this form
         if (!empty($formconfig['recipient_email'])) {
-            $message->setTo(array($formconfig['recipient_email'] => $formconfig['recipient_name']));
+            $sendToEmailsArray = explode(',', $formconfig['recipient_email']);
+            foreach ($sendToEmailsArray as $k => $v){
+              $v = trim($v);
+            }
+            $message->setTo(array_fill_keys($sendToEmailsArray, $formconfig['recipient_name']));
             $this->app['log']->add('Set Recipient for '. $formname . ' to '. $formconfig['recipient_email'], 3);
         }
 
@@ -651,11 +655,19 @@ class Extension extends \Bolt\BaseExtension
         else {
             // only add other recipients when not in testmode
             if(!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
-                $message->setCc($formconfig['recipient_cc_email']);
+                $sendToEmailsArray = explode(',', $formconfig['recipient_cc_email']);
+                foreach ($sendToEmailsArray as $k => $v){
+                  $v = trim($v);
+                }
+                $message->setCc(array_fill_keys($sendToEmailsArray, $formconfig['recipient_cc_email']));
                 $this->app['log']->add('Added Cc for '. $formname . ' to '. $formconfig['recipient_cc_email'], 3);
             }
             if(!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
-                $message->setBcc($formconfig['recipient_bcc_email']);
+                $sendToEmailsArray = explode(',', $formconfig['recipient_bcc_email']);
+                foreach ($sendToEmailsArray as $k => $v){
+                  $v = trim($v);
+                }
+                $message->setCc(array_fill_keys($sendToEmailsArray, $formconfig['recipient_bcc_email']));
                 $this->app['log']->add('Added Bcc for '. $formname . ' to '. $formconfig['recipient_bcc_email'], 3);
             }
 

--- a/Extension.php
+++ b/Extension.php
@@ -25,6 +25,18 @@ class Extension extends \Bolt\BaseExtension
     {
         return Extension::NAME;
     }
+    
+    /**
+     * Allow users to place {{ simpleforms() }} tags into content, if
+     * `allowtwig: true` is set in the contenttype.
+     *
+     * @return boolean
+     */
+    public function isSafe()
+    {
+        return true;
+    }
+
 
     public function initialize()
     {

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ myformname:
 </pre>
 
 
-Save to database:
+Save to database, CSV, and/or Pardot:
 -----------------
 
 There is an option to keep a logfile in the database of all form submissions.
@@ -316,6 +316,10 @@ CREATE TABLE `notifications` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 </pre>
+
+You may also save data into a CSV file. Just like the `insert_into_table` field, create a field for `insert_into_csv` and specify a filename of file you would like entries appended to. If file doesn't exist, SimpleForms will attempt to create it for you. The CSV file is attempted to be created at the root of your Bolt (2.0) installation, however, you can attempt to save it below the root (e.g. `../myCSV.csv`) or in a subdirectory.
+
+If you use Pardot, you can also setup a pardot FormHandler and then assign its URL to a `send_to_pardot` field. Data will be sent through a cURL request. Make sure to use the same FormHandler URL type - HTTP or HTTPS (TLS/SSL) - as used on your form page.
 
 
 special log fields

--- a/README.md
+++ b/README.md
@@ -53,8 +53,15 @@ The default file has two forms defined, namely 'contact' and 'demo'. The structu
 
 <pre>
 myformname:
-  recipient_email: info@example.org
-  recipient_name: Info
+  recipients: 
+    - 
+      name: Info
+      email: info@example.org
+    - 
+      name: Sales 
+      email: sales@example.org
+  recipient_cc_email: john@example.org
+  recipient_cc_name: John
   mail_subject: "[Simpleforms] Contact from site"
   fields:
     fieldname:
@@ -68,8 +75,10 @@ myformname:
 
 Each form has a name, which is used to insert the correct form in your templates. For example, if you've named your
 form `myformname`, as in the example above, you can insert the form in your templates using
-`{{ simpleform('myformname') }}`. Use the `recipient_email` and `recipient_info` fields to set the recipients of the
-emails. Use the `mail_subject` value to set the subject of the confirmation emails. The optional `button_text` can be
+`{{ simpleform('myformname') }}`. Use the `recipient_email` and `recipient_name` fields to set the recipients of the
+emails. Alternatively, to set a number of recipient emails (or CC/BCC recipients), create a list of 'email' and 'name' sets 
+like in above example under 'recipients', 'recipients_cc', and/or 'recipients_bcc'; a list of recipients will override a single 
+recipient. Use the `mail_subject` value to set the subject of the confirmation emails. The optional `button_text` can be
 used to override the global setting for the text on the 'send' button.
 
 Each of the 'General settings' mentioned above can be overridden for a specific form. So, you can create forms that use

--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ CREATE TABLE `notifications` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 </pre>
 
-You may also save data into a CSV file. Just like the `insert_into_table` field, create a field for `insert_into_csv` and specify a filename of file you would like entries appended to. If file doesn't exist, SimpleForms will attempt to create it for you. The CSV file is attempted to be created at the root of your Bolt (2.0) installation, however, you can attempt to save it below the root (e.g. `../myCSV.csv`) or in a subdirectory.
+You may also save data into a CSV file. Just like the `insert_into_table` field, create a field for `insert_into_csv` and specify a filename of file you would like entries appended to. If file doesn't exist, SimpleForms will attempt to create it for you. The CSV file is attempted to be created at the root of your Bolt (2.0) installation, however, you can attempt to save/use a file below the root (e.g. `../myCSV.csv`) or in a subdirectory.
 
-If you use Pardot, you can also setup a pardot FormHandler and then assign its URL to a `send_to_pardot` field. Data will be sent through a cURL request. Make sure to use the same FormHandler URL type - HTTP or HTTPS (TLS/SSL) - as used on your form page.
+If you use Pardot, you can also setup a pardot FormHandler (see Pardot documentation) for your form and then assign its URL to a `send_to_pardot` field. In the Pardot FormHandler configuration, fields must be correctly mapped from field names in your form's YAML configuration to Pardot fields. Ensure that fields which you set to be required in Pardot are also required in the SimpleForm config. Form data will be transmitted through a cURL request. Make sure to use the same FormHandler URL type - HTTP or HTTPS (TLS/SSL -- preferred) - as used on your form page.
 
 
 special log fields

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Save to database, CSV, and/or Pardot:
 -----------------
 
 **SQL Database**
+
 There is an option to keep a logfile in the database of all form submissions.
 For this log you need to make a table with columns named after the fieldnames in the form and set the `insert_into_table`
 for the form to the tablename. This extension will not automatically create the table, and it will produce an error if
@@ -319,9 +320,11 @@ CREATE TABLE `notifications` (
 </pre>
 
 **CSV File**
+
 You may also save data into a CSV file. Just like the `insert_into_table` field, create a field for `insert_into_csv` and specify a filename of file you would like entries appended to. If file doesn't exist, SimpleForms will attempt to create it for you. The CSV file is attempted to be created at the root of your Bolt (2.0) installation, however, you can attempt to save/use a file below the root (e.g. `../myCSV.csv`) or in a subdirectory.
 
 **Pardot**
+
 If you use Pardot, you can also setup a pardot FormHandler (see Pardot documentation) for your form and then assign its URL to a `send_to_pardot` field. In the Pardot FormHandler configuration, fields must be correctly mapped from field names in your form's YAML configuration to Pardot fields. Ensure that fields which you set to be required in Pardot are also required in the SimpleForm config. Form data will be transmitted through a cURL request. Make sure to use the same FormHandler URL type - HTTP or HTTPS (TLS/SSL -- preferred) - as used on your form page.
 
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ myformname:
 Each form has a name, which is used to insert the correct form in your templates. For example, if you've named your
 form `myformname`, as in the example above, you can insert the form in your templates using
 `{{ simpleform('myformname') }}`. Use the `recipient_email` and `recipient_name` fields to set the recipients of the
-emails. Alternatively, to set a number of recipient emails (or CC/BCC recipients), create a list of `email` and `name` sets 
-like in above example under `recipients`, `recipients_cc`, and/or `recipients_bcc`; a list of recipients will override a single 
-recipient. Use the `mail_subject` value to set the subject of the confirmation emails. The optional `button_text` can be
-used to override the global setting for the text on the 'send' button.
+emails. Additionally, to set a number of recipient emails (or CC/BCC recipients), can create a list of `email` and 
+`name` sets like in above example under `recipients`, `recipients_cc`, and/or `recipients_bcc`; if both list and the `recipient_email` and `recipient_name` are present, the latter will be prepended as a name & email pair to this list. Use the `mail_subject` value to set the subject of the confirmation emails. The 
+optional `button_text` can be used to override the global setting for the text on the 'send' button.
 
 Each of the 'General settings' mentioned above can be overridden for a specific form. So, you can create forms that use
 different templates and different messages.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ myformname:
 Save to database, CSV, and/or Pardot:
 -----------------
 
+**SQL Database**
 There is an option to keep a logfile in the database of all form submissions.
 For this log you need to make a table with columns named after the fieldnames in the form and set the `insert_into_table`
 for the form to the tablename. This extension will not automatically create the table, and it will produce an error if
@@ -317,8 +318,10 @@ CREATE TABLE `notifications` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 </pre>
 
+**CSV File**
 You may also save data into a CSV file. Just like the `insert_into_table` field, create a field for `insert_into_csv` and specify a filename of file you would like entries appended to. If file doesn't exist, SimpleForms will attempt to create it for you. The CSV file is attempted to be created at the root of your Bolt (2.0) installation, however, you can attempt to save/use a file below the root (e.g. `../myCSV.csv`) or in a subdirectory.
 
+**Pardot**
 If you use Pardot, you can also setup a pardot FormHandler (see Pardot documentation) for your form and then assign its URL to a `send_to_pardot` field. In the Pardot FormHandler configuration, fields must be correctly mapped from field names in your form's YAML configuration to Pardot fields. Ensure that fields which you set to be required in Pardot are also required in the SimpleForm config. Form data will be transmitted through a cURL request. Make sure to use the same FormHandler URL type - HTTP or HTTPS (TLS/SSL -- preferred) - as used on your form page.
 
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ myformname:
 Each form has a name, which is used to insert the correct form in your templates. For example, if you've named your
 form `myformname`, as in the example above, you can insert the form in your templates using
 `{{ simpleform('myformname') }}`. Use the `recipient_email` and `recipient_name` fields to set the recipients of the
-emails. Alternatively, to set a number of recipient emails (or CC/BCC recipients), create a list of 'email' and 'name' sets 
-like in above example under 'recipients', 'recipients_cc', and/or 'recipients_bcc'; a list of recipients will override a single 
+emails. Alternatively, to set a number of recipient emails (or CC/BCC recipients), create a list of `email` and `name` sets 
+like in above example under `recipients`, `recipients_cc`, and/or `recipients_bcc`; a list of recipients will override a single 
 recipient. Use the `mail_subject` value to set the subject of the confirmation emails. The optional `button_text` can be
 used to override the global setting for the text on the 'send' button.
 


### PR DESCRIPTION
Hey this branch contains edits re: last comments from patch-1 re: recipient_email (and recipient_name, recipient_cc_email, etc.), which is now prepended into array list (when/if exists; else if it exists without array it becomes only member of array), and the rest of code cleaned up a bit. 
This also includes a couple of options/functs for saving to CSV and Pardot which am using on our site that figured might be useful (doc included). Let me know if you don't want these or have any suggestions/feedback for them. The prior (updated) patch (multiple recipients only) is #7 Multiple Recipient Emails (patch-1 branch on my fork) and can pull request that too ASAP if wanted instead.
