### PR TITLE
Multiple Recipients + <select> option val fix.

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -331,7 +331,7 @@ class Extension extends \Bolt\BaseExtension
                             $message = $formconfig['message_ok'];
                             $sent = true;
 
-                            // If redirect_on_ok is set, redirect to that page when succesful.
+                            // If redirect_on_ok is set, redirect to that page when successful.
                             if (!empty($formconfig['redirect_on_ok'])) {
                                 $redirectpage = $this->app['storage']->getContent($formconfig['redirect_on_ok']);
                                 if ($formconfig['debugmode']==true) {
@@ -396,6 +396,14 @@ class Extension extends \Bolt\BaseExtension
             \Dumper::dump($data);
             \Dumper::dump($this->app['request']->files);
         }
+        
+        // Check recipients arrays & push/convert single recipients to front of it.
+        if (empty($formconfig['recipients']))       $formconfig['recipients'] = array();
+        if (empty($formconfig['recipients_cc']))    $formconfig['recipients_cc'] = array();
+        if (empty($formconfig['recipients_bcc']))   $formconfig['recipients_bcc'] = array();
+        if (!empty($formconfig['recipient_email']))     array_unshift($formconfig['recipients'], array('email' => $formconfig['recipient_email'], 'name' => $formconfig['recipient_name']));
+        if (!empty($formconfig['recipient_cc_email']))  array_unshift($formconfig['recipients_cc'], array('email' => $formconfig['recipient_cc_email'], 'name' => $formconfig['recipient_cc_name']));
+        if (!empty($formconfig['recipient_bcc_email'])) array_unshift($formconfig['recipients_bcc'], array('email' => $formconfig['recipient_bcc_email'], 'name' => $formconfig['recipient_bcc_name']));
 
         // $data contains the posted data. For legibility, change boolean fields to "yes" or "no".
         foreach($data as $key => $value) {
@@ -440,37 +448,34 @@ class Extension extends \Bolt\BaseExtension
                         case 'to_email':
                             // add another recipient
                             // add the values to the formconfig in case we want to see this later
-                            $formconfig['recipient_email'] = $tmp_email;
-                            $formconfig['recipient_name'] = $tmp_name;
+                            $formconfig['recipients'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                             if($formconfig['debugmode']==true) {
-                                \Dumper::dump('Overriding recipient_email for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
+                                \Dumper::dump('Adding to recipients for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
                             }
                             break;
                         case 'cc_email':
                             // add another carbon copy recipient
-                            $formconfig['recipient_cc_email'] = $tmp_email;
-                            $formconfig['recipient_cc_name'] = $tmp_name;
+                            $formconfig['recipients_cc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                             if($formconfig['debugmode']==true) {
-                                \Dumper::dump('Overriding recipient_cc_email for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
+                                \Dumper::dump('Adding to recipients_cc for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
                             }
                             break;
                         case 'bcc_email':
                             // add another blind carbon copy recipient
-                            $formconfig['recipient_bcc_email'] = $tmp_email;
-                            $formconfig['recipient_bcc_name'] = $tmp_name;
+                            $formconfig['recipients_bcc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                             if($formconfig['debugmode']==true) {
-                                \Dumper::dump('Overriding recipient_bcc_email for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
+                                \Dumper::dump('Adding to recipients_bcc for '.$formname . ' with '. $tmp_name . ' <'. $tmp_email.'>');
                             }
                             break;
                     }
                 } elseif(is_array($value)) {
                     // replace keys with values for display in the email
                     foreach($value as $k => $v) {
-                        if($options[$v] != $v) {
+                        if($options[$v] !== $v) {
                             $data[$key][$k] = $options[$v];
                         }
                     }
-                } elseif(isset($options[$value]) && $options[$value] != $value) {
+                } elseif(isset($options[$value]) && $options[$value] !== $value) {
                     $data[$key] = $options[$value];
                 }
 
@@ -579,6 +584,7 @@ class Extension extends \Bolt\BaseExtension
             \Dumper::dump('Prepared files for '.$formname);
             \Dumper::dump($data);
         }
+        
 
         // Attempt to insert the data into a table, if specified..
         if (!empty($formconfig['insert_into_table'])) {
@@ -608,17 +614,20 @@ class Extension extends \Bolt\BaseExtension
 
         if (!empty($formconfig['mail_subject'])) {
             $subject = $formconfig['mail_subject'];
-        }
-        else {
+        } else {
             $subject = '[SimpleForms] ' . $formname;
         }
 
         if (empty($formconfig['from_email'])) {
-            $formconfig['from_email'] = $formconfig['recipient_email'];
+            if (!empty($formconfig['recipients'][0]['name'])) {
+                $formconfig['from_email'] = $formconfig['recipients'][0]['email'];
+            }
         }
 
         if (empty($formconfig['from_name'])) {
-            $formconfig['from_name'] = $formconfig['recipient_name'];
+            if (!empty($formconfig['recipients'][0]['name'])) {
+                $formconfig['from_name'] = $formconfig['recipients'][0]['name'];
+            }
         }
 
         // Compile the message..
@@ -628,9 +637,13 @@ class Extension extends \Bolt\BaseExtension
             ->addPart($mailhtml, 'text/html');
 
         // set the default recipient for this form
-        if (!empty($formconfig['recipient_email'])) {
-            $message->setTo(array($formconfig['recipient_email'] => $formconfig['recipient_name']));
-            $this->app['log']->add('Set Recipient for '. $formname . ' to '. $formconfig['recipient_email'], 3);
+        if (!empty($formconfig['recipients'])) {
+            $sendToEmailsArray = array();
+            foreach ($formconfig['recipients'] as $emailEntry){
+                $sendToEmailsArray[$emailEntry['email']] = $emailEntry['name'];
+            }
+            $message->setTo($sendToEmailsArray);
+            $this->app['log']->add('Set Recipients for '. $formname . ' to '. implode(', ', array_keys($sendToEmailsArray)), 3);
         }
 
         // set the default sender for this form
@@ -645,29 +658,46 @@ class Extension extends \Bolt\BaseExtension
                 $message->attach($attachment);
             }
         }
+        
+        // utility lambda to grab email from set (array) of name & email
+        $getFromEmailSet = function($arrayOfEmailName, $property = 'email'){
+            return $arrayOfEmailName[$property];
+        };
 
         // check for testmode
         if($formconfig['testmode']==true) {
             // override recipient with debug recipient
-            $message->setTo(array($formconfig['testmode_recipient'] => $formconfig['recipient_name']));
+            $message->setTo(array($formconfig['testmode_recipient'] => $formconfig['recipients'][0]['name']));
 
             // do not add other cc and bcc addresses in testmode
-            if(!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
-                $this->app['log']->add('Did not set Cc for '. $formname . ' to '. $formconfig['recipient_cc_email'] . ' (in testmode)', 3);
+            if(!empty($formconfig['recipients_cc']) && $formconfig['recipients']!=$formconfig['recipients_cc']) {
+                $this->app['log']->add('Did not set Cc for '. $formname . ' (in testmode)', 3);
             }
-            if(!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
-                $this->app['log']->add('Did not set Bcc for '. $formname . ' to '. $formconfig['recipient_bcc_email'] . ' (in testmode)', 3);
+            if(!empty($formconfig['recipients_bcc']) && $formconfig['recipients']!=$formconfig['recipients_bcc']) {
+                $this->app['log']->add('Did not set Bcc for '. $formname . ' (in testmode)', 3);
             }
         }
         else {
             // only add other recipients when not in testmode
-            if(!empty($formconfig['recipient_cc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_cc_email']) {
-                $message->setCc($formconfig['recipient_cc_email']);
-                $this->app['log']->add('Added Cc for '. $formname . ' to '. $formconfig['recipient_cc_email'], 3);
+            if(!empty($formconfig['recipients_cc'])) {
+                $sendToEmailsArray = array();
+                foreach ($formconfig['recipients_cc'] as $emailEntry){
+                    if (!in_array($emailEntry['email'], array_map($getFromEmailSet, $formconfig['recipients']))){
+                        $sendToEmailsArray[$emailEntry['email']] = $emailEntry['name'];
+                    }
+                }
+                $message->setCc($sendToEmailsArray);
+                $this->app['log']->add('Set CC for '. $formname . ' to '. implode(', ', array_keys($sendToEmailsArray)), 3);
             }
-            if(!empty($formconfig['recipient_bcc_email']) && $formconfig['recipient_email']!=$formconfig['recipient_bcc_email']) {
-                $message->setBcc($formconfig['recipient_bcc_email']);
-                $this->app['log']->add('Added Bcc for '. $formname . ' to '. $formconfig['recipient_bcc_email'], 3);
+            if(!empty($formconfig['recipients_bcc'])) {
+                $sendToEmailsArray = array();
+                foreach ($formconfig['recipients_bcc'] as $emailEntry){
+                    if (!in_array($emailEntry['email'], array_map($getFromEmailSet, $formconfig['recipients']))){
+                        $sendToEmailsArray[$emailEntry['email']] = $emailEntry['name'];
+                    }
+                }
+                $message->setBcc($sendToEmailsArray);
+                $this->app['log']->add('Added Bcc for '. $formname . ' to '. implode(', ', array_keys($sendToEmailsArray)), 3);
             }
 
             // check for other email addresses to be added
@@ -682,11 +712,8 @@ class Extension extends \Bolt\BaseExtension
                             $tmp_name = $data[$values['use_with']];
                             if(!$tmp_name) {
                                 $tmp_name = $tmp_email;
-                            } else {
-                                $formconfig['recipient_name'] = $tmp_name;
-                            }
-                        }
-                        else {
+                            } 
+                        } else {
                             $tmp_name = $tmp_email;
                         }
                     }
@@ -716,26 +743,26 @@ class Extension extends \Bolt\BaseExtension
                             case 'to_email':
                                 // check if recipient name is something useful
                                 // if it is already set somewhere use that
-                                if(!isset($formconfig['recipient_name'])) {
-                                    $formconfig['recipient_name'] = $tmp_name;
+                                if(!isset($formconfig['recipients'][0]['name']) || empty($formconfig['recipients'][0]['name'])) {
+                                    $formconfig['recipients'][0]['name'] = $tmp_name;
                                 } else {
-                                    $tmp_name = $formconfig['recipient_name'];
+                                    $tmp_name = $formconfig['recipients'][0]['name'];
                                 }
                                 // add another recipient
 
                                 $message->addTo($tmp_email, $tmp_name);
                                 // add the values to the formconfig in case we want to see this later
-                                if (empty($formconfig['recipient_email'])) {
-                                    $formconfig['recipient_email'] = $tmp_email;
-                                }
+                                $formconfig['recipients'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                                 break;
                             case 'cc_email':
                                 // add another carbon copy recipient
                                 $message->addCc($tmp_email, $tmp_name);
+                                $formconfig['recipients_cc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                                 break;
                             case 'bcc_email':
                                 // add another blind carbon copy recipient
                                 $message->addBcc($tmp_email, $tmp_name);
+                                $formconfig['recipients_bcc'][] = array('name' => $tmp_name, 'email' => $tmp_email);
                                 break;
                         }
                     }
@@ -746,17 +773,22 @@ class Extension extends \Bolt\BaseExtension
         // log the attempt
         $this->app['log']->add('Sending message '. $formname
                                . ' from '. $formconfig['from_email']
-                               . ' to '. $formconfig['recipient_email'], 3);
+                               . ' to '. implode(', ', array_map($getFromEmailSet, $formconfig['recipients'])), 3);
 
         $res = $this->app['mailer']->send($message);
 
         // log the result of the attempt
         if ($res) {
             if($formconfig['testmode']) {
-                $this->app['log']->add('Sent email from ' . $formname . ' to '. $formconfig['testmode_recipient'] . ' (in testmode) - ' . $formconfig['recipient_name'], 3);
+                $this->app['log']->add('Sent email from ' . $formname . ' to '. $formconfig['testmode_recipient'] . ' (in testmode)', 3);
             }
             else {
-                $this->app['log']->add('Sent email from ' . $formname . ' to '. $formconfig['recipient_email'] . ' - ' . $formconfig['recipient_name'], 3);
+                $this->app['log']->add('Sent email from ' . $formname . ' to '. implode(', ', array_map($getFromEmailSet, $formconfig['recipients'])) . ' - ' . implode(', ', array_map($getFromEmailSet, $formconfig['recipients'], array_fill(0, count($formconfig['recipients']), 'name'))), 3);
+            }
+            if($formconfig['debugmode']==true) {
+                \Dumper::dump('Recipients Below');
+                \Dumper::dump($formconfig['recipients']);
+                \Dumper::dump(array_map($getFromEmailSet, $formconfig['recipients']));
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,15 @@ The default file has two forms defined, namely 'contact' and 'demo'. The structu
 
 <pre>
 myformname:
-  recipient_email: info@example.org
-  recipient_name: Info
+  recipients: 
+    - 
+      name: Info
+      email: info@example.org
+    - 
+      name: Sales 
+      email: sales@example.org
+  recipient_cc_email: john@example.org
+  recipient_cc_name: John
   mail_subject: "[Simpleforms] Contact from site"
   fields:
     fieldname:
@@ -73,9 +80,10 @@ myformname:
 
 Each form has a name, which is used to insert the correct form in your templates. For example, if you've named your
 form `myformname`, as in the example above, you can insert the form in your templates using
-`{{ simpleform('myformname') }}`. Use the `recipient_email` and `recipient_info` fields to set the recipients of the
-emails. Use the `mail_subject` value to set the subject of the confirmation emails. The optional `button_text` can be
-used to override the global setting for the text on the 'send' button.
+`{{ simpleform('myformname') }}`. Use the `recipient_email` and `recipient_name` fields to set the recipients of the
+emails. Additionally, to set a number of recipient emails (or CC/BCC recipients), can create a list of `email` and 
+`name` sets like in above example under `recipients`, `recipients_cc`, and/or `recipients_bcc`; if both list and the `recipient_email` and `recipient_name` are present, the latter will be prepended as a name & email pair to this list. Use the `mail_subject` value to set the subject of the confirmation emails. The 
+optional `button_text` can be used to override the global setting for the text on the 'send' button.
 
 Each of the 'General settings' mentioned above can be overridden for a specific form. So, you can create forms that use
 different templates and different messages.


### PR DESCRIPTION
Changes -
a) Allow array of {'name' : Recipient Name, 'email': recipient@example.org } to be used in YAML config for new fields recipients, recipients_cc, and recipients_bcc, in addition to current recipient_email and recipient_name which get merged into this array, if any.
b) Fix issue where Option w/ value '0' in form gets saved as '0' rather than label ('!=' to '!==' , add type comparison) .

Please double-test if possible -- tested with various combinations of recipients(_cc) and recipient_email (etc.) (outside of testmode ( + w/ testmode, w/ debugmode). Did not test form fields with "use as to_email" but should work (only minor edits in that area, now appended to recipients array instd. of replacing recipient_email).

Thx!
- Alex
