### PR TITLE
Translate the text that is displayed on the button to submit the form

### DIFF
--- a/assets/simpleforms_form.twig
+++ b/assets/simpleforms_form.twig
@@ -23,6 +23,6 @@
         {{ recaptcha_html|raw }}
     </div>
     {% endif %}
-    <input type="submit" name="submit" value="{{ button_text }}" class="simpleform-submit" />
+    <input type="submit" name="submit" value="{{ __(button_text) }}" class="simpleform-submit" />
 </form>
 {% endif %}


### PR DESCRIPTION
I noticed that all field labels are translated except for the text that is displayed on the button. This fixes that. :)
