### PR TITLE
- Fix issue with choice field when first option is selected

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -500,7 +500,7 @@ class Extension extends \Bolt\BaseExtension
                             $data[$key][$k] = $options[$v];
                         }
                     }
-                } elseif(isset($options[$value]) && $options[$value] != $value) {
+                } elseif(isset($options[$value]) && $options[$value] !== $value) {
                     $data[$key] = $options[$value];
                 }
 


### PR DESCRIPTION
As also described in #17 when the first option is selected the label of that option isn't shown but instead shows the integer of that choice, which is 0.

The code checks by using `!=` which converts the type of the two variables to be the same. 

This comparison casts the first parameter to an int since `$value` is an int and `options[$value]` is therefore also casted to an int which is impossible so it becomes 0. 

The comparison then becomes `0 != 0` which is false and this leads to the result that 0 is returned instead of the actual label of that choice.

I hope this is clear.
